### PR TITLE
cherry pie recipe with new eggs

### DIFF
--- a/src/main/resources/data/brewingandbaking/recipe/cherry_pie.json
+++ b/src/main/resources/data/brewingandbaking/recipe/cherry_pie.json
@@ -5,7 +5,7 @@
     "W": "minecraft:wheat",
     "C": "brewingandbaking:cherry",
     "S": "minecraft:sugar",
-    "E": "minecraft:egg"
+    "E": "#minecraft:eggs"
   },
   "result": {
     "id": "brewingandbaking:cherry_pie",


### PR DESCRIPTION
Makes the cherry pie item craftable with the new Blue Egg and Brown Egg items (and any future chicken eggs they add).